### PR TITLE
Allow check_scheme to be set

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -30,6 +30,7 @@ Annotations on Ingress objects:
 * ``consulk8s/check_timeout`` - Timeout for Consul health check. Defaults to 2s.
 * ``consulk8s/check_path`` - Path segment of URL to make HTTP health check request. Defaults to '/'.
 * ``consulk8s/tls_skip_verify`` - Skip TLS verification. Consul defaults to false.
+* ``consulk8s/check_scheme`` - HTTP scheme, either 'http' or 'https' - Allows setting SSL on ports other than 443
 
 .. |Status| image:: https://img.shields.io/travis/joshbenner/consulk8s.svg?
    :target: https://travis-ci.org/joshbenner/consulk8s

--- a/consulk8s.py
+++ b/consulk8s.py
@@ -121,7 +121,8 @@ def k8s_ingresses_as_services(ingresses, default_ip, interval):
 
         check_timeout = ann.get('consulk8s/check_timeout', '2s')
         check_path = ann.get('consulk8s/check_path', '/').lstrip('/')
-        check_scheme = 'https' if port == 443 else 'http'
+        default_scheme = 'https' if port == 443 else 'http'
+        check_scheme = ann.get('consulk8s/check_scheme', default_scheme)
 
         check = OrderedDict((
             ('name', '{} check'.format(name)),

--- a/tests/test_write_ingresses.py
+++ b/tests/test_write_ingresses.py
@@ -204,7 +204,48 @@ ingress_cases = (
             )
         ],
         []
-    )
+    ),
+
+    # Checking forcing SSL on port 8443
+    (
+        [
+            MockModel(
+                metadata=MockModel(
+                    name='foo-service',
+                    namespace='default',
+                    annotations={
+                        'consulk8s/service': 'foo',
+                        'consulk8s/address': '127.0.0.6',
+                        'consulk8s/port': '8443',
+                        'consulk8s/check_scheme': 'https',
+                    },
+                ),
+                spec=MockModel(rules=[MockModel(host='foo.test.tld')]),
+                status=MockModel(load_balancer=MockModel(ingress=[
+                    MockModel(ip='127.0.0.6')
+                ]))
+            )
+        ],
+        [
+            {
+                'id': 'consulk8s_foo',
+                'name': 'foo',
+                'address': '127.0.0.6',
+                'port': 8443,
+                'checks': [
+                    {
+                        'name': 'foo check',
+                        'notes': 'HTTP check foo.test.tld on port '
+                                 '8443 every 30s',
+                        'http': 'https://127.0.0.6:8443/',
+                        'header': {'Host': ['foo.test.tld']},
+                        'interval': '30s',
+                        'timeout': '2s'
+                    }
+                ]
+            }
+        ]
+    ),
 )
 
 


### PR DESCRIPTION
This allows users to manually set `check_scheme` via annotation, forcing http or https if needed.

Why? Because there are ports other than 443 that use SSL, e.g. 8443 which is used by Apache Tomcat or any other case where you cannot use 443 for some reason.